### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -41,7 +41,7 @@ tests:
         - jsonpickle
         - pandas
         - sqlalchemy
-        - python ${{ python_min }}
+        - python ${{ python_min }}.*
     script:
       - python -m klepto.tests
 


### PR DESCRIPTION
Add explicit `.*` glob suffix to bare python version specifiers like `python ${{ python_min }}` to make them valid match specs.

This is a build-fix only — the existing package on conda-forge is unaffected, so no new build needs to be pushed. That's why the build number isn't bumped.